### PR TITLE
Fixed issue for tablet landscape mode, and fixed some typos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ Step by step "daggerization" of a common application.
 Instructions
 ------------
 
-The workshop consists in a series of exercises which are identified in the master branch of the repo by tags.
-The solutions of each exercise are tagged in the repo as well (don't look at them before you tried the exercise! Don't cheat on me!)
+The workshop consists of a series of exercises which are indicated in the master branch of the repo by tags.
+The solutions of each of the exercises are tagged in the repo as well (don't look at them before you've tried the exercise! Don't cheat on me!)
 
-The exercise are:
-- Exercise #1: Your first injection! Inject a simple object as a String is.
-- Exercise #2: Increase a little the complexity, inject a class. Several solutions included!
+The exercises are:
+- Exercise #1: Your first injection! Inject a simple object such as a String.
+- Exercise #2: Increase the complexity a little, inject a class. Several solutions included!
 - Exercise #3: A real world example, inject a class with dependencies.
 - Exercise #4: #PerfMatters... Introducing scopes!
-- Exercise #5: Became a master in Dagger 2
+- Exercise #5: Become a master in Dagger 2
 - Exercise #6: That's easy, right?
 
-To complete the workshop you need a Marvel account in order to get all the amazing comics from our favorite super hero.
-You can get it at <a href="http://developer.marvel.com/">Developer Marvel</a> by registering and getting a key. Once you have your key, go to string resources and put your key on!
+To complete the workshop you'll need a Marvel account in order to get all the amazing comics from our favorite super heroes.
+You can get it at <a href="http://developer.marvel.com/">Developer Marvel</a> by registering and getting a key. Once you have your key, go to string resources and put your key in!

--- a/app/src/main/java/com/smassive/daggerworkshopgdg/app/view/activity/MainActivity.java
+++ b/app/src/main/java/com/smassive/daggerworkshopgdg/app/view/activity/MainActivity.java
@@ -15,10 +15,9 @@
  */
 package com.smassive.daggerworkshopgdg.app.view.activity;
 
-import com.smassive.daggerworkshopgdg.app.AndroidApplication;
 import com.smassive.daggerworkshopgdg.app.R;
-import com.smassive.daggerworkshopgdg.app.UIThread;
 import com.smassive.daggerworkshopgdg.app.injector.component.ApplicationComponent;
+import com.smassive.daggerworkshopgdg.app.injector.component.ComicsComponent;
 import com.smassive.daggerworkshopgdg.app.injector.component.DaggerComicsComponent;
 import com.smassive.daggerworkshopgdg.app.injector.module.ActivityModule;
 import com.smassive.daggerworkshopgdg.app.injector.module.ComicsModule;
@@ -26,14 +25,6 @@ import com.smassive.daggerworkshopgdg.app.model.ComicModel;
 import com.smassive.daggerworkshopgdg.app.presenter.ComicsPresenter;
 import com.smassive.daggerworkshopgdg.app.view.adapter.ComicsAdapter;
 import com.smassive.daggerworkshopgdg.app.view.fragment.ComicDetailFragment;
-import com.smassive.daggerworkshopgdg.data.executor.JobExecutor;
-import com.smassive.daggerworkshopgdg.data.repository.ComicsRepositoryImpl;
-import com.smassive.daggerworkshopgdg.data.repository.datasource.ComicDataStoreFactory;
-import com.smassive.daggerworkshopgdg.domain.executor.PostExecutionThread;
-import com.smassive.daggerworkshopgdg.domain.executor.ThreadExecutor;
-import com.smassive.daggerworkshopgdg.domain.interactor.GetComicsUseCase;
-import com.smassive.daggerworkshopgdg.domain.interactor.GetComicsUseCaseImpl;
-import com.smassive.daggerworkshopgdg.domain.repository.ComicsRepository;
 
 import android.app.Fragment;
 import android.app.FragmentTransaction;
@@ -77,11 +68,14 @@ public class MainActivity extends BaseActivity
     @Named("character_id")
     int characterId;
 
+    private ComicsComponent comicsComponent;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
         ButterKnife.bind(this);
+        comicsComponent.inject(this);
 
         setUpToolbar(false);
 
@@ -105,10 +99,14 @@ public class MainActivity extends BaseActivity
         applicationComponent.inject(this);
 
         // PerActivity injector initialization
-        DaggerComicsComponent.builder()
+        comicsComponent = DaggerComicsComponent.builder()
                 .applicationComponent(applicationComponent) // Main component must be set
                 .activityModule(new ActivityModule(this)) // Initialize dependencies
-                .comicsModule(new ComicsModule()).build().inject(this); // Make PerActivity module
+                .comicsModule(new ComicsModule()).build(); // Make PerActivity module
+    }
+
+    public ComicsComponent getComicsComponent() {
+        return comicsComponent;
     }
 
     private void initializePresenter() {

--- a/app/src/main/java/com/smassive/daggerworkshopgdg/app/view/fragment/ComicDetailFragment.java
+++ b/app/src/main/java/com/smassive/daggerworkshopgdg/app/view/fragment/ComicDetailFragment.java
@@ -18,19 +18,11 @@ package com.smassive.daggerworkshopgdg.app.view.fragment;
 import com.google.common.base.Strings;
 
 import com.smassive.daggerworkshopgdg.app.R;
-import com.smassive.daggerworkshopgdg.app.UIThread;
 import com.smassive.daggerworkshopgdg.app.model.ComicModel;
 import com.smassive.daggerworkshopgdg.app.presenter.ComicDetailPresenter;
 import com.smassive.daggerworkshopgdg.app.presenter.Presenter;
 import com.smassive.daggerworkshopgdg.app.view.activity.ComicDetailActivity;
-import com.smassive.daggerworkshopgdg.data.executor.JobExecutor;
-import com.smassive.daggerworkshopgdg.data.repository.ComicsRepositoryImpl;
-import com.smassive.daggerworkshopgdg.data.repository.datasource.ComicDataStoreFactory;
-import com.smassive.daggerworkshopgdg.domain.executor.PostExecutionThread;
-import com.smassive.daggerworkshopgdg.domain.executor.ThreadExecutor;
-import com.smassive.daggerworkshopgdg.domain.interactor.GetComicUseCase;
-import com.smassive.daggerworkshopgdg.domain.interactor.GetComicUseCaseImpl;
-import com.smassive.daggerworkshopgdg.domain.repository.ComicsRepository;
+import com.smassive.daggerworkshopgdg.app.view.activity.MainActivity;
 import com.squareup.picasso.Picasso;
 
 import android.app.Activity;
@@ -91,7 +83,11 @@ public class ComicDetailFragment extends BaseFragment {
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
-        ((ComicDetailActivity) getActivity()).getComicsComponent().inject(this);
+        if (getActivity() instanceof ComicDetailActivity) {
+            ((ComicDetailActivity) getActivity()).getComicsComponent().inject(this);
+        } else {
+            ((MainActivity) getActivity()).getComicsComponent().inject(this);
+        }
 
         comicDetailPresenter.setView(this);
         comicId = getArguments().getInt(ARG_COMIC_ID);


### PR DESCRIPTION
App was crashing when used on a tablet in landscape mode because ComicDetailFragment was looking for the ComicsComponent in the ComicDetailActivity when in landscape mode the fragment was instantiated by the MainActivity.
